### PR TITLE
Attach a WsServer to each App worker

### DIFF
--- a/server/src/game/server.rs
+++ b/server/src/game/server.rs
@@ -22,6 +22,7 @@ pub struct WsServer {
 }
 
 impl WsServer {
+    /// Creates a new [`WsServer`].
     pub fn new() -> Self {
         WsServer::default()
     }

--- a/server/src/game/server.rs
+++ b/server/src/game/server.rs
@@ -15,19 +15,10 @@ struct Game {
 }
 
 /// The game server which manages the active games.
+#[derive(Default)]
 pub struct WsServer {
     users: HashMap<UserId, Recipient<ServerMessage>>,
     games: HashMap<String, Game>,
-}
-
-impl WsServer {
-    /// Creates a new [`WsServer`].
-    pub fn new() -> Self {
-        Self {
-            users: HashMap::new(),
-            games: HashMap::new(),
-        }
-    }
 }
 
 impl Actor for WsServer {

--- a/server/src/game/server.rs
+++ b/server/src/game/server.rs
@@ -20,7 +20,15 @@ pub struct WsServer {
     games: HashMap<String, Game>,
 }
 
-impl WsServer {}
+impl WsServer {
+    /// Creates a new [`WsServer`].
+    pub fn new() -> Self {
+        Self {
+            users: HashMap::new(),
+            games: HashMap::new(),
+        }
+    }
+}
 
 impl Actor for WsServer {
     /// [`WsServer`] is as generic as possible, accepting any type of context.

--- a/server/src/game/server.rs
+++ b/server/src/game/server.rs
@@ -21,6 +21,12 @@ pub struct WsServer {
     games: HashMap<String, Game>,
 }
 
+impl WsServer {
+    pub fn new() -> Self {
+        WsServer::default()
+    }
+}
+
 impl Actor for WsServer {
     /// [`WsServer`] is as generic as possible, accepting any type of context.
     type Context = Context<Self>;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,7 +29,7 @@ fn get_session_secret() -> Key {
 async fn main() -> io::Result<()> {
     env_logger::init();
 
-    let game_server = WsServer::new().start();
+    let game_server = WsServer::default().start();
 
     HttpServer::new(move || {
         App::new()

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,9 +3,12 @@ mod routes;
 
 use std::io;
 
+use actix::Actor;
 use actix_files::Files;
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::{cookie::Key, middleware::Logger, web, App, HttpServer};
+
+use crate::game::server::WsServer;
 
 /// Returns a secret key that is used to encrypt the session cookie stored by the client.
 ///
@@ -26,8 +29,11 @@ fn get_session_secret() -> Key {
 async fn main() -> io::Result<()> {
     env_logger::init();
 
-    HttpServer::new(|| {
+    let game_server = WsServer::new().start();
+
+    HttpServer::new(move || {
         App::new()
+            .app_data(web::Data::new(game_server.clone()))
             .wrap(Logger::default())
             .wrap(
                 SessionMiddleware::builder(CookieSessionStore::default(), get_session_secret())


### PR DESCRIPTION
Spins up a `WsServer` instance and attaches it to the App as application data which provides an `Arc` of it to each worker.